### PR TITLE
Fix version tagging

### DIFF
--- a/lib/Date/Holidays/GB/EAW.pm
+++ b/lib/Date/Holidays/GB/EAW.pm
@@ -1,6 +1,6 @@
 package Date::Holidays::GB::EAW;
 
-our $VERSION = '0.018'; our $VERSION = '0.019'; # VERSION
+our $VERSION = '0.019'; # VERSION
 
 use strict;
 use warnings;

--- a/lib/Date/Holidays/GB/NIR.pm
+++ b/lib/Date/Holidays/GB/NIR.pm
@@ -1,6 +1,6 @@
 package Date::Holidays::GB::NIR;
 
-our $VERSION = '0.018'; our $VERSION = '0.019'; # VERSION
+our $VERSION = '0.019'; # VERSION
 
 use strict;
 use warnings;

--- a/lib/Date/Holidays/GB/SCT.pm
+++ b/lib/Date/Holidays/GB/SCT.pm
@@ -1,6 +1,6 @@
 package Date::Holidays::GB::SCT;
 
-our $VERSION = '0.018'; our $VERSION = '0.019'; # VERSION
+our $VERSION = '0.019'; # VERSION
 
 use strict;
 use warnings;


### PR DESCRIPTION
Or should it just be `# VERSION` and it gets automatically added when a dist is built (and the dist version got committed by mistake)? :shrug: 